### PR TITLE
Bump aiohttp from 3.9.3 to 3.12.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiofiles
-aiohttp==3.9.3
+aiohttp==3.12.13
 alphabet_detector
 apscheduler
 asyncio


### PR DESCRIPTION
---
updated-dependencies:
- dependency-name: aiohttp dependency-version: 3.12.13 dependency-type: direct:production update-type: version-update:semver-minor ...